### PR TITLE
Allow declaring explicit username and password

### DIFF
--- a/intake_dremio/dremio_cat.py
+++ b/intake_dremio/dremio_cat.py
@@ -3,31 +3,27 @@ from intake.catalog.local import LocalCatalogEntry
 from pyarrow import flight
 
 from . import __version__
-from .intake_dremio import DremioSource, DremioClientAuthMiddlewareFactory, HttpDremioClientAuthHandler
+from .intake_dremio import (
+    DremioSource, DremioClientAuthMiddlewareFactory, HttpDremioClientAuthHandler,
+    process_uri
+)
 
 
 class DremioCatalog(Catalog):
-    
+
     name = 'dremio_cat'
 
     __version__ = __version__
-    
+
     _sql_expr = 'select * from INFORMATION_SCHEMA."TABLES"'
 
-    def __init__(self, uri, tls=False, cert=None, **kwargs):
+    def __init__(self, uri, username=None, password=None, tls=False, cert=None, **kwargs):
         self._tls = tls
         self._certs = cert
         self._uri = uri
-        if '://' in uri:
-            self._protocol, uri = uri.split('://')
-            if tls and 'tls' not in self._protocol:
-                raise ValueError(f"TLS was enabled but protocol {self._protocol}"
-                                 "does not supported encrypted connection.")
-        else:
-            self._protocol = 'grpc+tls' if tls else 'grpc+tcp'
-        userinfo, hostname = uri.split('@')
-        self._hostname = hostname
-        self._user, self._password = userinfo.split(':')
+        self._protocol, self._hostname, self._user, self._password = process_uri(
+            uri, tls=tls, user=username, password=password
+        )
         super(DremioCatalog, self).__init__(**kwargs)
 
     def _load(self):

--- a/intake_dremio/intake_dremio.py
+++ b/intake_dremio/intake_dremio.py
@@ -77,9 +77,6 @@ def process_uri(uri, tls=False, user=None, password=None):
     """
     if '://' in uri:
         protocol, uri = uri.split('://')
-        if tls and 'tls' not in protocol:
-            raise ValueError(f"TLS was enabled but protocol {self._protocol} "
-                             "does not supported encrypted connection.")
     else:
         protocol = 'grpc+tls' if tls else 'grpc+tcp'
     if '@' in uri:
@@ -139,6 +136,9 @@ class DremioSource(base.DataSource):
         self._protocol, self._hostname, self._user, self._password = process_uri(
             uri, tls=tls, user=username, password=password
         )
+        if tls and 'tls' not in self._protocol:
+            raise ValueError(f"TLS was enabled but protocol {self._protocol} "
+                             "does not supported encrypted connection.")
         if cert is not None and tls:
             with open(cert, "rb") as root_certs:
                 self._certs = root_certs.read()


### PR DESCRIPTION
Sometimes the username or password cannot be declared via the URI (e.g. because it contains `:` or `@` which are used as delimiters).