### PR TITLE
Normalize source names on catalog access

### DIFF
--- a/intake_dremio/dremio_cat.py
+++ b/intake_dremio/dremio_cat.py
@@ -49,9 +49,9 @@ class DremioCatalog(Catalog):
         return super().__getitem__(key)
 
     def _create_entry(self, row):
-        name = f'{row.TABLE_SCHEMA}."{row.TABLE_NAME}"'
+        path = f'"{row.TABLE_SCHEMA}"."{row.TABLE_NAME}"'
         description = f'Dremio {row.TABLE_TYPE} {name} from {self._source._hostname}'
-        args = dict(self._source._init_args, sql_expr=f'SELECT * FROM {name}')
+        args = dict(self._source._init_args, sql_expr=f'SELECT * FROM {path}')
         e = LocalCatalogEntry(name, description, 'dremio', True,
                               args, {}, {}, {}, "", getenv=True,
                               getshell=False)

--- a/intake_dremio/dremio_cat.py
+++ b/intake_dremio/dremio_cat.py
@@ -44,8 +44,8 @@ class DremioCatalog(Catalog):
     def __getitem__(self, key):
         normalized_key = key.replace('"', '').lower()
         cats = list(self)
-        normalized_cats = [cat.replace('"', '').lower() for cat in self]
-        if key not in self and normalized_key in normalized_cats:
+        normalized_cats = [cat.replace('"', '').lower() for cat in cats]
+        if key not in cats and normalized_key in normalized_cats:
             key = cats[normalized_cats.index(normalized_key)]
         return super().__getitem__(key)
 

--- a/intake_dremio/dremio_cat.py
+++ b/intake_dremio/dremio_cat.py
@@ -43,9 +43,10 @@ class DremioCatalog(Catalog):
 
     def __getitem__(self, key):
         normalized_key = key.replace('"', '').lower()
-        cats = [cat.replace('"', '').lower() for cat in self]
-        if key not in self and normalized_key in cats:
-            key = cats[cats.index(normalized_key)]
+        cats = list(self)
+        normalized_cats = [cat.replace('"', '').lower() for cat in self]
+        if key not in self and normalized_key in normalized_cats:
+            key = cats[normalized_cats.index(normalized_key)]
         return super().__getitem__(key)
 
     def _create_entry(self, row):

--- a/intake_dremio/dremio_cat.py
+++ b/intake_dremio/dremio_cat.py
@@ -51,13 +51,13 @@ class DremioCatalog(Catalog):
 
     def _create_entry(self, row):
         path = f'"{row.TABLE_SCHEMA}"."{row.TABLE_NAME}"'
-        description = f'Dremio {row.TABLE_TYPE} {name} from {self._source._hostname}'
+        description = f'Dremio {row.TABLE_TYPE} {path} from {self._source._hostname}'
         args = dict(self._source._init_args, sql_expr=f'SELECT * FROM {path}')
-        e = LocalCatalogEntry(name, description, 'dremio', True,
+        e = LocalCatalogEntry(path, description, 'dremio', True,
                               args, {}, {}, {}, "", getenv=True,
                               getshell=False)
         e._plugin = [DremioSource]
-        self._entries[name] = e
+        self._entries[path] = e
 
     def _repr_html_(self):
         (css_style,) = _load_static_files()

--- a/intake_dremio/dremio_cat.py
+++ b/intake_dremio/dremio_cat.py
@@ -41,6 +41,13 @@ class DremioCatalog(Catalog):
         for _, row in self._dataframe.iterrows():
             self._create_entry(row)
 
+    def __getitem__(self, key):
+        normalized_key = key.replace('"', '').lower()
+        cats = [cat.replace('"', '').lower() for cat in self]
+        if key not in self and normalized_key in cats:
+            key = cats[cats.index(normalized_key)]
+        return super().__getitem__(key)
+
     def _create_entry(self, row):
         name = f'{row.TABLE_SCHEMA}."{row.TABLE_NAME}"'
         description = f'Dremio {row.TABLE_TYPE} {name} from {self._source._hostname}'


### PR DESCRIPTION
The `DremioCatalog` currently fetches the paths of all the tables from an index table in Dremio which provides the `TABLE_SCHEMA` and the `TABLE_NAME`. It then generates the SQL query to fetch each of these tables. To make those queries work consistently I put quotes around both components of the path, i.e. we end up with "{TABLE_SCHEMA}"."{TABLE_NAME}". These quotes are only important for the query however, therefore when a user attempts dictionary-like access on the catalog we can normalize the key and the paths to the tables with `.replace('"', '').lower()`. This is safe because Dremio is not case sensitive in the table schema and table naming, i.e. a path without quotes and all lower-case will always uniquely identify a single table.

### TL;DR

A catalog containing a table with the path `"Samples.samples.dremio.com"."NYC-taxi-trips" can now be accessed with:

```
cat['samples.samples.dremio.com.nyc-taxi-trips']
cat['SAMPLES.samples.dremio.com.NYC-TAXI-TRIPS']
cat['"samples.samples.dremio.com"."NYC-TAXI-TRIPS"']
cat['"samples.samples.dremio.com"."nyc-taxi-trips"']
cat['samples.samples.dremio.com."NYC-taxi-trips"']
...
```